### PR TITLE
Added 'NULL' option, it means no resize!

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and you can use helper in templates
 <img src="{$photo|thumb:'100x300':'fit'}">
 ```
 Size can be in next formats:
+* ```NULL``` - Size of photo will be the same as original picture, no resized
 * ```100x``` - Width will be 100px and height will be automatically calculated
 * ```x100``` - Width will be automatically calculated and height will be 100px
 * ```100x100``` - Size will be 100pxx100px

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ and you can use helper in templates
 <img src="{$photo|thumb:'100x300':'fit'}">
 ```
 Size can be in next formats:
-* ```NULL``` - Size of photo will be the same as original picture, no resized
 * ```100x``` - Width will be 100px and height will be automatically calculated
 * ```x100``` - Width will be automatically calculated and height will be 100px
 * ```100x100``` - Size will be 100pxx100px

--- a/src/Kappa/ThumbnailsHelper/Thumbnails.php
+++ b/src/Kappa/ThumbnailsHelper/Thumbnails.php
@@ -101,7 +101,9 @@ class Thumbnails
 			if (!$this->configurator->getSizeUp() && $image->width <= $this->sizes[0] && $image->getHeight() <= $this->sizes[1]) {
 				return $this->source->getInfo();
 			} else {
-				$image->resize($this->sizes[0], $this->sizes[1], $this->flag);
+				if($image->width != $this->sizes[0] || $image->getHeight() != $this->sizes[1]) {
+					$image->resize($this->sizes[0], $this->sizes[1], $this->flag);
+				}
 				$file = File::fromImage($image, $thumbnail);
 
 				return $file->getInfo();

--- a/src/Kappa/ThumbnailsHelper/Thumbnails.php
+++ b/src/Kappa/ThumbnailsHelper/Thumbnails.php
@@ -29,9 +29,6 @@ class Thumbnails
 	/** @var int */
 	private $flag = Image::FIT;
 
-	/** @var boolean */
-	private $resize = true;
-
 	/** @var \Kappa\FileSystem\File */
 	private $source;
 
@@ -50,15 +47,12 @@ class Thumbnails
 	 */
 	public function setSizes($sizes)
 	{
-		if($sizes == NULL) {
-			$this->resize = false;
-		} else {
-			$sizes = explode("x", $sizes);
-			if (count($sizes) != 2) {
-				throw new InvalidArgumentException("Size '{$sizes}' has not valid format");
-			}
-			$this->sizes = array_map(array($this, "parseSize"), $sizes);
+		$sizes = explode("x", $sizes);
+		if (count($sizes) != 2) {
+			throw new InvalidArgumentException("Size '{$sizes}' has not valid format");
 		}
+		$this->sizes = array_map(array($this, "parseSize"), $sizes);
+
 		return $this;
 	}
 
@@ -104,13 +98,7 @@ class Thumbnails
 			return new SplFileInfo($thumbnail);
 		} else {
 			$image = $this->source->toImage();
-			if($this->resize == false) {
-				$this->sizes[0] = $image->width;
-				$this->sizes[1] = $image->height;
-
-				$file = File::fromImage($image, $thumbnail);
-				return $file->getInfo();
-			} else if (!$this->configurator->getSizeUp() && $image->width <= $this->sizes[0] && $image->getHeight() <= $this->sizes[1]) {
+			if (!$this->configurator->getSizeUp() && $image->width <= $this->sizes[0] && $image->getHeight() <= $this->sizes[1]) {
 				return $this->source->getInfo();
 			} else {
 				$image->resize($this->sizes[0], $this->sizes[1], $this->flag);
@@ -143,4 +131,4 @@ class Thumbnails
 			return (int)$size;
 		}
 	}
-}
+} 


### PR DESCRIPTION
Example: I want user to upload file 128x128 and no other sizes. But method resize() is able to decrease size of file > 0px. Thats problem, i want use the same file as user uploaded, no 127x127. When is photo opened array with sizes is filled with origin values.
